### PR TITLE
added https redirect to security module

### DIFF
--- a/modules/security/controllers/Security.php
+++ b/modules/security/controllers/Security.php
@@ -25,5 +25,14 @@ class Security extends Trongate {
         }
         return $randomString;
     }
+   
+	function _redirect_https(){
+		if (empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] === "off") {
+			$location = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+			header('HTTP/1.1 301 Moved Permanently');
+			header('Location: ' . $location);
+			exit;
+		}		
+	}    
 
 }


### PR DESCRIPTION
The https redirect function can be called from any other module to improve security if site is accessed from a regular http url.