### PR TITLE
MODELDEBUG

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -2,6 +2,7 @@
 //The main config file
 define('BASE_URL', '');
 define('ENV', 'dev');
+define('MODELDEBUG', 'false');
 define('DEFAULT_MODULE', 'welcome');
 define('DEFAULT_CONTROLLER', 'Welcome');
 define('DEFAULT_METHOD', 'index');

--- a/engine/Model.php
+++ b/engine/Model.php
@@ -37,7 +37,7 @@ class Model {
 
            Then, add the below 5 lines
         */
-        if (MYSQLDEBUG !== ''){ 
+        if (MYSQLDEBUG !== ''|| MYSQLDEBUG !== 'true'){ 
             define('MODELDEBUG', 'false'); 
         }else{
             define('MODELDEBUG', 'true');

--- a/engine/Model.php
+++ b/engine/Model.php
@@ -9,7 +9,7 @@ class Model {
     private $dbh;
     private $stmt;
     private $error;
-    private $debug = false;
+    private $debug = MODELDEBUG;
     private $query_caveat = 'The query shown above is how the query would look <i>before</i> binding.';
 
     public function __construct() {
@@ -25,6 +25,22 @@ class Model {
         } catch(PDOException $e){
             $this->error = $e->getMessage();
             echo $this->error; die();
+        }
+
+        /*
+           Make debuging mysql accesible from the config file:
+           Replace 'private $debug = false;' with 'private $debug = MODELDEBUG;' (line 12) 
+
+           In /config/config.php add:
+           define('MODELDEBUG', 'true');
+           If the above line is not found, the debug setting will default to false
+
+           Then, add the below 5 lines
+        */
+        if (MYSQLDEBUG !== ''){ 
+            define('MODELDEBUG', 'false'); 
+        }else{
+            define('MODELDEBUG', 'true');
         }
 
     }


### PR DESCRIPTION
Added MODELDEBUG to config.php
$debug was previously only accessible from Model.php witch is part of the core framework. Its not advised that framework files are modified so this modification will benefit in the long run.