### PR TITLE
Fix $template undefined in engine/Pagination.php

### DIFF
--- a/engine/Pagination.php
+++ b/engine/Pagination.php
@@ -127,7 +127,7 @@ class Pagination {
 
         }
 
-        $target_settings_method = 'get_settings_'.$template;
+        $target_settings_method = 'get_settings_'.$pagination_template;
         $settings = self::$target_settings_method();
         $pagination_data['settings'] = $settings;
 


### PR DESCRIPTION
Address issue #11 

The $template on line 130 should be $pagination_template.