### PR TITLE
Removed some duplicate variables in Api.php

### DIFF
--- a/engine/Api.php
+++ b/engine/Api.php
@@ -1247,15 +1247,8 @@ class Api extends Trongate {
         $token_validation_data['module_name'] = $module_name;
         $token_validation_data['module_endpoints'] = $module_endpoints;
         $input['token'] = $this->_validate_token($token_validation_data);
-
         $output['token'] = $input['token'];
-
-        $token_validation_data['endpoint'] = $endpoint_name;
-        $token_validation_data['module_name'] = $module_name;
-        $token_validation_data['module_endpoints'] = $module_endpoints;
-        $input['token'] = $this->_validate_token($token_validation_data);
-        $output['token'] = $input['token'];
-
+        
         $fourth_bit = $this->url->segment(4);
 
         //get posted params (PHP doesn't differentiate btn GET and DELETE)

--- a/engine/Api.php
+++ b/engine/Api.php
@@ -1249,8 +1249,6 @@ class Api extends Trongate {
         $input['token'] = $this->_validate_token($token_validation_data);
         $output['token'] = $input['token'];
         
-        $fourth_bit = $this->url->segment(4);
-
         //get posted params (PHP doesn't differentiate btn GET and DELETE)
         $post = file_get_contents('php://input');
         $decoded = json_decode($post, true);


### PR DESCRIPTION
Removed some duplicate variables and also variable $fourth_bit doesn't seem to be used.

Api.php in function destroy() Starting at line 1246:

$token_validation_data['endpoint'] = $endpoint_name;
$token_validation_data['module_name'] = $module_name;
$token_validation_data['module_endpoints'] = $module_endpoints;
$input['token'] = $this ->_validate_token($token_validation_data);

$output['token'] = $input['token'];

$token_validation_data['endpoint'] = $endpoint_name;
$token_validation_data['module_name'] = $module_name;
$token_validation_data['module_endpoints'] = $module_endpoints;
$input['token'] = $this->_validate_token($token_validation_data);
$output['token'] = $input['token'];

$fourth_bit = $this->url->segment(4);