### PR TITLE
Line 58 $abs_file_path not used

### DIFF
--- a/engine/Core.php
+++ b/engine/Core.php
@@ -55,7 +55,6 @@ class Core {
                 }
 
                 $asset_path = '../modules/'.strtolower($target_module).'/assets/'.$target_dir.'/'.$file_name;   
-                $abs_file_path = str_replace('../', BASE_URL, $asset_path);
             
                 if (file_exists($asset_path)) {
                     $content_type = mime_content_type($asset_path);


### PR DESCRIPTION
If $abs_file_path is not intended to be used then line 58 should be removed as it is the core file, call str_replace method in a foreach loop may slow down the framework a fraction of a sec.