### PR TITLE
No error reporting in production mode

### DIFF
--- a/engine/bootstrap.php
+++ b/engine/bootstrap.php
@@ -6,6 +6,10 @@ require_once '../config/database.php';
 require_once '../config/site_owner.php';
 require_once 'get_segments.php';
 
+if(ENV !== 'dev') {
+    error_reporting(0);
+}
+
 spl_autoload_register(function($class_name) {
 
     if (strpos($class_name, '_helper')) {


### PR DESCRIPTION
Only show error reporting in dev mode, and turn off the error reporting in production mode.

The reason is straight forward, you don't want to expose what went wrong in the production mode.