### PR TITLE
Allow URL Segments to be accessed via a routed request.

### DIFF
--- a/engine/get_segments.php
+++ b/engine/get_segments.php
@@ -19,7 +19,7 @@ function get_segments($ignore_custom_routes=NULL) {
         $assumed_url = attempt_add_custom_routes($assumed_url);
     }
 
-    $data['assumed_url'] = $assumed_url;
+    $data['assumed_url'] = $assumed_url;   
 
     $assumed_url = str_replace('://', '', $assumed_url);
     $assumed_url = rtrim($assumed_url, '/');
@@ -30,23 +30,46 @@ function get_segments($ignore_custom_routes=NULL) {
         unset($segments[$i]);
     }
 
-    $data['segments'] = array_values($segments); 
+    $data['segments'] = array_values($segments);     
+
     return $data;
 }
 
 function attempt_add_custom_routes($target_url) {
-    //takes a nice URL and returns the assumed_url
-
-    $target_segment = str_replace(BASE_URL, '', $target_url);
-
-
+    //takes a nice URL and returns the assumed_url     
+    
+    $target_segments = str_replace(BASE_URL, '', $target_url);
+    $target_segments = explode('/', $target_segments); 
+    if(count($target_segments) > 20)
+        return $target_url;
+    $first_target_segment = $target_segments[0];    
+    
     foreach (CUSTOM_ROUTES as $key => $value) {
-
-        if ($key == $target_segment) {
-            $target_url = str_replace($key, $value, $target_url);
-        }
+        $key_segments = explode('/', $key); 
+        // check that first segment matches    
+        if ($key_segments[0] == $first_target_segment) {                     
+            // remove the segments that are different
+            $dif = array_diff($target_segments,$key_segments); 
+            foreach($dif as $dif_key => $dif_value){
+                unset($target_segments[$dif_key]);
+            }             
+            // rebuild target segments only allowing exact match to the route key 
+            $key_count = count($key_segments); 
+            for ($i = 0; $i < $key_count; $i++) {  
+                if(isset($target_segments[$i]))              
+                $matched_target_segments[] = $target_segments[$i];                
+            }
+            
+            $target_string = implode('/', $matched_target_segments);  
+                                     
+            if($target_string == $key) {                                
+                $additional_segmnets = implode('/',$dif);                        
+                $target_url = BASE_URL.$value.$additional_segmnets;
+                break;                
+            } 
+        }              
     }
-
+    
     return $target_url;
 }
 


### PR DESCRIPTION
I had a go at this previously but dropped the idea due to the solution being overcomplicated. I have now relooked at it and feel this is now a lot simpler and cleaner solution.

This mod allows us to access the URL segments for a routed request.

i.e a route of `some-route' => 'controller/method/'`

If we enter a URL such as 'some-route/a/b/c'. - we now have access in this instance to a, b & c params via the `this->url->segment` function. 

This also works if the route key has segments itself, such as `some-route/seg1/seg/2' => 'controller/method/'`

I included a limit to the number of segments of 20, this can be removed or defined in the config if required. The thought behind this was the previous concern of spam attacks. (Although I'm sure a throttler module is coming to the marketplace soon..)

I have tested this on the anchor() function and the asset manager and all is working well.  

Hopefully, you guys can see the benefit of this as I feel this mod allows for the use of generic modules to have their names easily changed via a route while maintaining full functionality.  

Cheers,
Spence




 










 