### PR TITLE
Fix 404 page while passing get params

### DIFF
--- a/engine/get_segments.php
+++ b/engine/get_segments.php
@@ -19,6 +19,10 @@ function get_segments($ignore_custom_routes=NULL) {
         $assumed_url = attempt_add_custom_routes($assumed_url);
     }
 
+    if($pos = strpos($assumed_url, '?')){
+        $assumed_url = substr($assumed_url, $pos, 0);
+    }
+
     $data['assumed_url'] = $assumed_url;
 
     $assumed_url = str_replace('://', '', $assumed_url);


### PR DESCRIPTION
I noticed I can't pass GET parameter

You can also see it by going to: https://trongate.io/docs?test=param

Here it is clear that were want to access `/docs` with some GET parameter but the frameworks treats it as a completely different route.
