### PR TITLE
concatenate "BASE_URL" not required

### DIFF
--- a/engine/tg_helpers/form_helper.php
+++ b/engine/tg_helpers/form_helper.php
@@ -16,7 +16,7 @@ function form_open($location, $attributes=NULL, $additional_code=NULL) {
     }
 
     if (filter_var($location, FILTER_VALIDATE_URL) === FALSE) {
-        $location = BASE_URL.$location;
+        $location = $location;
     }
 
     if (isset($additional_code)) {


### PR DESCRIPTION
```php
if (filter_var($location, FILTER_VALIDATE_URL) === FALSE) {
        $location = BASE_URL.$location;
    }
```
Here "$location" is carrying full URL i.e. http://your_domain.test/trongate_administrators/submit/1 . 
if we concatenate "BASE_URL" then it will look like=> http://your_domain.test/http://your_domain.test/trongate_administrators/submit/1
Hence, $location = $location; is without error.

```php 
if (filter_var($location, FILTER_VALIDATE_URL) === FALSE) {
        $location = $location;
    }
```