### PR TITLE
allow scrolling on modal in mobile mode 

### DIFF
--- a/public/css/trongate.css
+++ b/public/css/trongate.css
@@ -345,4 +345,8 @@ hr {
     width: 100%;
     display: block;
   }
+  .modal {
+    max-height: 85vh;
+    overflow-y: auto;
+  }
 }


### PR DESCRIPTION
	Allow scrolling on modal container when the height is greater than the screen 
       height of the device. Most apparent on mobile devices.