### PR TITLE
bugfix(Model.php): wrap keys backticks when inserting

### DIFF
--- a/engine/Model.php
+++ b/engine/Model.php
@@ -450,8 +450,9 @@ class Model {
         }
 
         // Construct the SQL query
-        $columns = implode(', ', array_keys($data));
-        $placeholders = ':' . implode(', :', array_keys($data));
+        $keys = array_keys($data);
+        $columns = implode(', ', array_map(fn ($key) => "`$key`", $keys));
+        $placeholders = ':' . implode(', :', $keys);
         $sql = "INSERT INTO $target_table ($columns) VALUES ($placeholders)";
 
         // Prepare and execute the query


### PR DESCRIPTION
Creating a record using a reserved word, e.g. key fails without backticks (`key`) escaping it.

This commit ensures that we can insert data into tables using reserved keywords as column names.

here's claude.ai 3.7 review of the changes

```
This PR change involves modifications to SQL query construction code in what appears to be PHP. Let me review the changes:

### Changes Made
- The original code used direct array keys for column names in the SQL query
- The updated code adds backticks (`) around column names for proper SQL escaping

### Analysis
This is a good change that improves security and compatibility:

1. **Adding backticks around column names**: This properly escapes column names, which prevents SQL syntax errors when column names match SQL reserved keywords (like `order`, `group`, `limit`, etc.).

2. **Code optimization**: The change stores `array_keys($data)` in a variable (`$keys`) first, then reuses it, which is slightly more efficient than calling `array_keys($data)` twice.

3. **Using arrow function**: The code uses the newer PHP arrow function syntax (`fn ($key) => ...`) for mapping, which is clean and modern.

### Recommendation
Approve the PR. This change:
- Improves SQL query security by properly escaping column identifiers
- Makes the code more robust against potential errors
- Slightly optimizes performance by avoiding duplicate function calls

The change is minimal and focused, with no apparent downsides.
```