### PR TITLE
Fix Language::load() returning wrong variable

### DIFF
--- a/modules/language/Language.php
+++ b/modules/language/Language.php
@@ -87,6 +87,6 @@ class Language extends Trongate {
 
         require $full_path;
 
-        return $validation_errors ?? [];
+        return $phrases ?? [];
     }
 }


### PR DESCRIPTION
The load() method in modules/language/Language.php was returning $validation_errors ?? [], but the documentation shows language files defining a $phrases array. This caused $this->language->load(...) to return an empty array when loading phrases.php files.

Changed to return $phrases ?? [] instead.

Fixes #225