### PR TITLE
Add note about automatic database creation

### DIFF
--- a/modules/setup/views/database_config.php
+++ b/modules/setup/views/database_config.php
@@ -38,6 +38,8 @@ echo form_label('Database Name', ['for' => 'database']);
 echo validation_errors('database');
 echo form_input('database', $database, ['id' => 'database', 'placeholder' => 'e.g. my_app', 'required' => 'required']);
 
+echo '<p class="mt-1 long-path"><strong>Note:</strong> Your database will be created automatically.</p>';
+
 echo form_submit('submit', 'Test Connection & Continue', ['class' => 'btn btn-primary']);
 echo form_close();
 ?>


### PR DESCRIPTION
Added a note to the database configuration form to clarify that the database is created automatically. This addresses a common point of confusion (as seen in my recent "First Look" video) where users might assume manual creation in phpMyAdmin is required.