### PR TITLE
Add password_handler child module

### DIFF
--- a/config/login.php
+++ b/config/login.php
@@ -34,6 +34,24 @@ $config['login'] = [
     'reset_token_lifespan' => 3600,
 
     // -----------------------------------------------------------------
+    // Optional password-strength rules
+    // -----------------------------------------------------------------
+    //
+    // Settings under 'password' control the password-strength validator
+    // provided by the password_handler child module. All keys are optional;
+    // any key you omit falls back to the default shown below. Rules apply
+    // globally to every user level — per-level overrides are not supported.
+    //
+    //   'password' => [
+    //       'min_length'      => 8,        // Minimum password length
+    //       'require_upper'   => false,    // Require at least one A-Z
+    //       'require_lower'   => false,    // Require at least one a-z
+    //       'require_digit'   => false,    // Require at least one digit
+    //       'require_special' => false,    // Require at least one non-alphanumeric
+    //       'deny_common'     => [],       // Array of disallowed passwords
+    //   ],
+
+    // -----------------------------------------------------------------
     // User-level definitions
     // -----------------------------------------------------------------
     //

--- a/modules/login/Login_model.php
+++ b/modules/login/Login_model.php
@@ -184,7 +184,8 @@ class Login_model extends Model {
             $hash_to_verify = $user->{$password_field};
         }
 
-        $password_valid = password_verify($password, $hash_to_verify);
+        $this->module('login-password_handler');
+        $password_valid = $this->password_handler->verify_password($password, $hash_to_verify);
 
         return ($user !== false)
             && !empty($user->{$password_field})
@@ -283,27 +284,20 @@ class Login_model extends Model {
     /**
      * Get a timing-safe bcrypt hash for the given user level.
      *
+     * Resolves the target table and password column from the level config,
+     * then delegates to the password_handler child module.
+     *
      * @param int $user_level_id The user level
      * @return string A valid bcrypt hash
      */
     private function get_timing_safe_hash(int $user_level_id): string {
         $config = $this->get_level_config($user_level_id);
-        $table = $config['target_table'];
-        $pw_field = $config['fields']['password']['column'];
-        $cost = $this->get_global_config('password_hash_cost') ?? 11;
+        $this->module('login-password_handler');
 
-        $sql = 'SELECT ' . $this->quote_id($pw_field)
-             . ' FROM ' . $this->quote_id($table)
-             . ' WHERE ' . $this->quote_id($pw_field) . ' IS NOT NULL'
-             . ' AND ' . $this->quote_id($pw_field) . " != '' LIMIT 1";
-
-        $rows = $this->db->query_bind($sql, [], 'object');
-
-        if (!empty($rows) && !empty($rows[0]->{$pw_field})) {
-            return $rows[0]->{$pw_field};
-        }
-
-        return password_hash('timing_protection_dummy', PASSWORD_BCRYPT, ['cost' => $cost]);
+        return $this->password_handler->get_timing_safe_hash(
+            $config['target_table'],
+            $config['fields']['password']['column']
+        );
     }
 
     // -----------------------------------------------------------------
@@ -560,6 +554,9 @@ class Login_model extends Model {
     /**
      * Generate a password reset token and return it.
      *
+     * Resolves the user's target table from the level config, then delegates
+     * token creation to the password_handler child module.
+     *
      * @param string $identifier The user's identifier (e.g., email)
      * @param int $user_level_id The user level
      * @return string|bool The reset token string, or false if user not found
@@ -572,20 +569,9 @@ class Login_model extends Model {
         }
 
         $config = $this->get_level_config($user_level_id);
-        $lifespan = $this->get_global_config('reset_token_lifespan') ?? 3600;
+        $this->module('login-password_handler');
 
-        $token = make_rand_str(64);
-
-        $this->db->insert([
-            'target_table' => $config['target_table'],
-            'identifier'   => $identifier,
-            'token'        => $token,
-            'expiry_date'  => time() + $lifespan,
-            'used'         => 0,
-            'created_at'   => time()
-        ], 'password_resets');
-
-        return $token;
+        return $this->password_handler->generate_reset_token($identifier, $config['target_table']);
     }
 
     /**
@@ -595,36 +581,31 @@ class Login_model extends Model {
      * @return object|bool The reset record, or false if invalid/expired
      */
     public function validate_reset_token(string $token): object|bool {
-        $sql = 'SELECT * FROM password_resets'
-             . ' WHERE token = :token'
-             . '   AND used = 0'
-             . '   AND expiry_date > :now'
-             . ' LIMIT 1';
-
-        $rows = $this->db->query_bind($sql, [
-            'token' => $token,
-            'now' => time()
-        ], 'object');
-
-        return !empty($rows) ? $rows[0] : false;
+        $this->module('login-password_handler');
+        return $this->password_handler->validate_reset_token($token);
     }
 
     /**
      * Update a user's password using a validated reset token.
+     *
+     * Orchestrates the login-specific reset flow: delegates the password
+     * write and token consumption to the password_handler child module,
+     * then wipes existing auth tokens for the user so all sessions are
+     * forced to re-authenticate.
      *
      * @param string $token The valid reset token
      * @param string $new_password The new plain-text password
      * @return bool True on success
      */
     public function reset_password(string $token, string $new_password): bool {
-        $reset = $this->validate_reset_token($token);
+        $this->module('login-password_handler');
+        $handler = $this->password_handler;
+
+        $reset = $handler->validate_reset_token($token);
 
         if ($reset === false) {
             return false;
         }
-
-        $cost = $this->get_global_config('password_hash_cost') ?? 11;
-        $hash = password_hash($new_password, PASSWORD_BCRYPT, ['cost' => $cost]);
 
         // Find the password field and primary identifier column for this target table
         $full = $this->load_config();
@@ -647,19 +628,19 @@ class Login_model extends Model {
             }
         }
 
-        // Update password in target table
-        $sql = 'UPDATE ' . $this->quote_id($reset->target_table)
-             . ' SET ' . $this->quote_id($pw_field) . ' = :hash'
-             . ' WHERE ' . $this->quote_id($ident_field) . ' = :identifier';
+        $success = $handler->update_password_for_identifier(
+            $reset->target_table,
+            $ident_field,
+            $reset->identifier,
+            $pw_field,
+            $new_password
+        );
 
-        $this->db->query_bind($sql, [
-            'hash' => $hash,
-            'identifier' => $reset->identifier
-        ]);
+        if ($success === false) {
+            return false;
+        }
 
-        // Mark token as used
-        $sql = 'UPDATE password_resets SET used = 1 WHERE token = :token';
-        $this->db->query_bind($sql, ['token' => $token]);
+        $handler->consume_reset_token($token);
 
         // Delete existing auth tokens for this user (force re-login)
         $user = $this->find_user($reset->identifier, $this->get_level_id_for_table($reset->target_table));
@@ -679,33 +660,15 @@ class Login_model extends Model {
     }
 
     /**
-     * Send a password reset email via the trongate_email module.
-     *
-     * Builds a plain-text message and delegates delivery to the
-     * dedicated Trongate email module, which handles SMTP
-     * communication, MIME formatting, and connection management.
+     * Send a password reset email via the password_handler child module.
      *
      * @param string $to_email The recipient email address
      * @param string $reset_link The full reset URL
      * @return bool True if sent successfully
      */
     public function send_reset_email(string $to_email, string $reset_link): bool {
-        $body = "Hello,\n\n";
-        $body .= "We received a request to reset your password.\n\n";
-        $body .= "Click the link below to reset your password:\n";
-        $body .= $reset_link . "\n\n";
-        $body .= "This link will expire in 1 hour.\n\n";
-        $body .= "If you did not request a password reset, you can safely ignore this email.\n";
-
-        $html_body = nl2br($body);
-
-        $this->module('trongate_email');
-
-        return $this->trongate_email->send([
-            'to_email' => $to_email,
-            'subject' => 'Password Reset Request',
-            'body_html' => '<p>' . $html_body . '</p>'
-        ]);
+        $this->module('login-password_handler');
+        return $this->password_handler->send_reset_email($to_email, $reset_link);
     }
 
     // -----------------------------------------------------------------
@@ -735,6 +698,30 @@ class Login_model extends Model {
     }
 
     /**
+     * Get the user level ID associated with a reset token, ignoring state.
+     *
+     * Unlike get_level_id_for_token(), this still resolves the level when
+     * the token has been used or has expired — used by the
+     * consumed/expired-token error page so it can link back to the correct
+     * forgot-password form.
+     *
+     * @param string $token The reset token
+     * @return int|null The user level ID, or null if the token is unknown
+     */
+    public function get_level_id_for_token_any(string $token): ?int {
+        $this->module('login-password_handler');
+        $reset = $this->password_handler->find_reset_token_row($token);
+
+        if ($reset === false) {
+            return null;
+        }
+
+        $level_id = $this->get_level_id_for_table($reset->target_table);
+
+        return ($level_id > 0) ? $level_id : null;
+    }
+
+    /**
      * Get the user level ID for a given target table name.
      *
      * @param string $table_name
@@ -755,12 +742,15 @@ class Login_model extends Model {
     /**
      * Hash a password using bcrypt.
      *
+     * Delegates to the password_handler child module so the same cost
+     * factor and bcrypt configuration is used everywhere.
+     *
      * @param string $password Plain-text password
      * @return string bcrypt hash
      */
     public function hash_password(string $password): string {
-        $cost = $this->get_global_config('password_hash_cost') ?? 11;
-        return password_hash($password, PASSWORD_BCRYPT, ['cost' => $cost]);
+        $this->module('login-password_handler');
+        return $this->password_handler->hash_password($password);
     }
 
     /**

--- a/modules/login/forgot_password/Forgot_password.php
+++ b/modules/login/forgot_password/Forgot_password.php
@@ -192,9 +192,12 @@ class Forgot_password extends Trongate {
             return;
         }
 
-        // Validate password
-        if (empty($password) || strlen($password) < 8) {
-            $data['error_message'] = 'Password must be at least 8 characters long.';
+        // Validate password strength via the password_handler child module
+        $this->module('login-password_handler');
+        $strength = $this->password_handler->validate_strength($password);
+
+        if ($strength !== true) {
+            $data['error_message'] = $strength;
             $data['token'] = $token;
             $data['form_location'] = BASE_URL . 'login/submit_reset_password';
             $this->view('reset_password_form', $data);

--- a/modules/login/password_handler/Password_handler.php
+++ b/modules/login/password_handler/Password_handler.php
@@ -1,0 +1,312 @@
+<?php
+/**
+ * Password Handler Child Module
+ *
+ * Provides shared password operations — hashing, verification, strength
+ * validation, reset-token lifecycle, and reset-email composition — for the
+ * Login module and any other module (sign-up, profile-edit, admin-set) that
+ * needs to touch passwords. Loaded by the Login parent module. The controller
+ * exposes the public API; the model handles only DB access. No URL endpoints.
+ */
+class Password_handler extends Trongate {
+
+    private array $password_config = [];
+
+    /**
+     * Constructor
+     *
+     * @param string|null $module_name The module name (auto-provided by framework)
+     */
+    public function __construct(?string $module_name = null) {
+        parent::__construct($module_name);
+        $this->parent_module = 'login';
+    }
+
+    // -----------------------------------------------------------------
+    // Configuration
+    // -----------------------------------------------------------------
+
+    /**
+     * Load password-related configuration from the login config file.
+     *
+     * Reads APPPATH/config/login.php. If absent, the built-in defaults
+     * apply. New password-strength keys are expected under
+     * $config['login']['password']; the legacy top-level keys
+     * 'password_hash_cost' and 'reset_token_lifespan' remain readable
+     * from their existing location.
+     *
+     * @return array The merged password configuration
+     */
+    private function load_password_config(): array {
+        if (!empty($this->password_config)) {
+            return $this->password_config;
+        }
+
+        $defaults = [
+            'min_length'           => 8,
+            'require_upper'        => false,
+            'require_lower'        => false,
+            'require_digit'        => false,
+            'require_special'      => false,
+            'deny_common'          => [],
+            'hash_cost'            => 11,
+            'reset_token_lifespan' => 3600
+        ];
+
+        $config = [];
+
+        $app_config = APPPATH . '/config/login.php';
+        if (file_exists($app_config)) {
+            require $app_config;
+        }
+
+        $login = $config['login'] ?? [];
+
+        // Legacy top-level keys (backward compatibility)
+        if (isset($login['password_hash_cost'])) {
+            $defaults['hash_cost'] = $login['password_hash_cost'];
+        }
+        if (isset($login['reset_token_lifespan'])) {
+            $defaults['reset_token_lifespan'] = $login['reset_token_lifespan'];
+        }
+
+        // New password sub-array (overlays defaults)
+        $password = $login['password'] ?? [];
+        $this->password_config = array_merge($defaults, $password);
+
+        return $this->password_config;
+    }
+
+    // -----------------------------------------------------------------
+    // Hashing & Verification
+    // -----------------------------------------------------------------
+
+    /**
+     * Hash a plain-text password using bcrypt.
+     *
+     * The cost factor is read from config ('password_hash_cost'),
+     * defaulting to 11.
+     *
+     * @param string $plain The plain-text password
+     * @return string The bcrypt hash
+     */
+    public function hash_password(string $plain): string {
+        $config = $this->load_password_config();
+        return password_hash($plain, PASSWORD_BCRYPT, ['cost' => $config['hash_cost']]);
+    }
+
+    /**
+     * Verify a plain-text password against a stored bcrypt hash.
+     *
+     * @param string $plain The submitted plain-text password
+     * @param string $hash The stored bcrypt hash
+     * @return bool True if the password matches the hash
+     */
+    public function verify_password(string $plain, string $hash): bool {
+        return password_verify($plain, $hash);
+    }
+
+    /**
+     * Get a timing-safe bcrypt hash for the given table.
+     *
+     * Returns an existing hash from the target table when possible, or a
+     * dummy hash otherwise. Used during credential verification to keep
+     * timing roughly constant whether or not the submitted user exists,
+     * preventing username enumeration via response-time analysis.
+     *
+     * @param string $target_table The user table
+     * @param string $password_field The column that stores password hashes
+     * @return string A valid bcrypt hash
+     */
+    public function get_timing_safe_hash(string $target_table, string $password_field): string {
+        $existing = $this->model->find_existing_password_hash($target_table, $password_field);
+
+        if ($existing !== null) {
+            return $existing;
+        }
+
+        return $this->hash_password('timing_protection_dummy');
+    }
+
+    // -----------------------------------------------------------------
+    // Strength Validation
+    // -----------------------------------------------------------------
+
+    /**
+     * Validate a password against the configured strength rules.
+     *
+     * Returns true on pass, or a single human-readable error string on the
+     * first failed check so the user fixes one thing at a time. Check order:
+     * minimum length, digit, uppercase, lowercase, special character, deny-list.
+     *
+     * @param string $plain The plain-text password to validate
+     * @return true|string True on pass, error message string on first failure
+     */
+    public function validate_strength(string $plain): true|string {
+        $config = $this->load_password_config();
+        $min = (int) $config['min_length'];
+
+        if (strlen($plain) < $min) {
+            return 'Password must be at least ' . $min . ' characters long.';
+        }
+
+        if (!empty($config['require_digit']) && !preg_match('/\d/', $plain)) {
+            return 'Password must contain at least one digit.';
+        }
+
+        if (!empty($config['require_upper']) && !preg_match('/[A-Z]/', $plain)) {
+            return 'Password must contain at least one uppercase letter.';
+        }
+
+        if (!empty($config['require_lower']) && !preg_match('/[a-z]/', $plain)) {
+            return 'Password must contain at least one lowercase letter.';
+        }
+
+        if (!empty($config['require_special']) && !preg_match('/[^A-Za-z0-9]/', $plain)) {
+            return 'Password must contain at least one special character.';
+        }
+
+        $deny = $config['deny_common'] ?? [];
+        if (!empty($deny) && is_array($deny) && in_array($plain, $deny, true)) {
+            return 'That password is on the list of disallowed passwords. Please choose another.';
+        }
+
+        return true;
+    }
+
+    // -----------------------------------------------------------------
+    // Reset Token Lifecycle
+    // -----------------------------------------------------------------
+
+    /**
+     * Generate a password reset token for the given identifier and table.
+     *
+     * Writes a row into the password_resets table with the configured
+     * lifespan. Returns the 64-character token string.
+     *
+     * @param string $identifier The user's identifier (e.g. email or username)
+     * @param string $target_table The user table the token applies to
+     * @return string The new reset token
+     */
+    public function generate_reset_token(string $identifier, string $target_table): string {
+        $config = $this->load_password_config();
+        $expiry = time() + (int) $config['reset_token_lifespan'];
+
+        $token = make_rand_str(64);
+
+        $this->model->insert_reset_token($identifier, $target_table, $token, $expiry);
+
+        return $token;
+    }
+
+    /**
+     * Validate a reset token.
+     *
+     * Returns the password_resets row if the token exists, has not been
+     * used, and has not expired. Returns false otherwise.
+     *
+     * @param string $token The reset token
+     * @return object|bool The reset record on success, false otherwise
+     */
+    public function validate_reset_token(string $token): object|bool {
+        return $this->model->find_active_reset_token($token);
+    }
+
+    /**
+     * Find any reset-token row by token string, regardless of state.
+     *
+     * Returns the row whether the token has been used or has expired —
+     * unlike `validate_reset_token()`, which returns false in those cases.
+     * Used so the consumed/expired-token error page can derive the
+     * originating user level and link back to the correct form.
+     *
+     * @param string $token The reset token
+     * @return object|bool The reset record on success, false if no such row
+     */
+    public function find_reset_token_row(string $token): object|bool {
+        return $this->model->find_reset_token_row($token);
+    }
+
+    /**
+     * Mark a reset token as consumed.
+     *
+     * Idempotent — calling this on an already-consumed token is a no-op.
+     *
+     * @param string $token The reset token
+     * @return void
+     */
+    public function consume_reset_token(string $token): void {
+        $this->model->mark_reset_token_used($token);
+    }
+
+    // -----------------------------------------------------------------
+    // Password Write
+    // -----------------------------------------------------------------
+
+    /**
+     * Hash a new password and write it to a target table.
+     *
+     * Hashes the plain-text password, then delegates the column-validated
+     * UPDATE to the model. Returns false if the target table is missing
+     * either the identifier column or the password column.
+     *
+     * @param string $target_table The user table
+     * @param string $identifier_column The column to match on
+     * @param string $identifier_value The value to match
+     * @param string $password_field The column that stores the hashed password
+     * @param string $new_plain The new plain-text password
+     * @return bool True on success, false if the table or columns are wrong
+     */
+    public function update_password_for_identifier(
+        string $target_table,
+        string $identifier_column,
+        string $identifier_value,
+        string $password_field,
+        string $new_plain
+    ): bool {
+        $hash = $this->hash_password($new_plain);
+
+        return $this->model->write_password_hash_for_identifier(
+            $target_table,
+            $identifier_column,
+            $identifier_value,
+            $password_field,
+            $hash
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Reset Email Composition
+    // -----------------------------------------------------------------
+
+    /**
+     * Send a password reset email via the trongate_email module.
+     *
+     * Builds a plain-text message and delegates delivery to the dedicated
+     * Trongate email module, which handles SMTP communication, MIME
+     * formatting, and connection management.
+     *
+     * @param string $to_email The recipient email address
+     * @param string $reset_link The full reset URL
+     * @return bool True if sent successfully
+     */
+    public function send_reset_email(string $to_email, string $reset_link): bool {
+        $body = "Hello,\n\n";
+        $body .= "We received a request to reset your password.\n\n";
+        $body .= "Click the link below to reset your password:\n";
+        $body .= $reset_link . "\n\n";
+        $body .= "This link will expire in 1 hour.\n\n";
+        $body .= "If you did not request a password reset, you can safely ignore this email.\n";
+
+        $html_body = nl2br($body);
+
+        $this->module('trongate_email');
+
+        return $this->trongate_email->send([
+            'to_email' => $to_email,
+            'subject' => 'Password Reset Request',
+            'body_html' => '<p>' . $html_body . '</p>'
+        ]);
+    }
+
+}

--- a/modules/login/password_handler/Password_handler_model.php
+++ b/modules/login/password_handler/Password_handler_model.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Password Handler Model
+ *
+ * Pure DB layer for the password_handler child module. Owns the queries
+ * against the password_resets table and the password-column UPDATE on
+ * target user tables. All business logic (hashing, strength validation,
+ * config loading, email composition, timing-safe fallback) lives in the
+ * Password_handler controller; this model is only invoked by it.
+ */
+class Password_handler_model extends Model {
+
+    // -----------------------------------------------------------------
+    // Password Hash Lookup
+    // -----------------------------------------------------------------
+
+    /**
+     * Find an existing password hash on the target table.
+     *
+     * Returns the first non-empty hash from the password column, or null
+     * if the table contains no rows with a stored hash. Used by the
+     * controller's timing-safe-hash routine.
+     *
+     * @param string $target_table The user table
+     * @param string $password_field The column that stores password hashes
+     * @return string|null The hash if found, null otherwise
+     */
+    public function find_existing_password_hash(string $target_table, string $password_field): ?string {
+        $sql = 'SELECT ' . $this->quote_id($password_field)
+             . ' FROM ' . $this->quote_id($target_table)
+             . ' WHERE ' . $this->quote_id($password_field) . ' IS NOT NULL'
+             . ' AND ' . $this->quote_id($password_field) . " != '' LIMIT 1";
+
+        $rows = $this->db->query_bind($sql, [], 'object');
+
+        if (!empty($rows) && !empty($rows[0]->{$password_field})) {
+            return $rows[0]->{$password_field};
+        }
+
+        return null;
+    }
+
+    // -----------------------------------------------------------------
+    // Reset Token CRUD
+    // -----------------------------------------------------------------
+
+    /**
+     * Insert a new reset-token row into the password_resets table.
+     *
+     * @param string $identifier The user's identifier (e.g. email or username)
+     * @param string $target_table The user table the token applies to
+     * @param string $token The 64-character token string
+     * @param int $expiry Unix timestamp at which the token expires
+     * @return void
+     */
+    public function insert_reset_token(string $identifier, string $target_table, string $token, int $expiry): void {
+        $this->db->insert([
+            'target_table' => $target_table,
+            'identifier'   => $identifier,
+            'token'        => $token,
+            'expiry_date'  => $expiry,
+            'used'         => 0,
+            'created_at'   => time()
+        ], 'password_resets');
+    }
+
+    /**
+     * Find an active reset-token row by token string.
+     *
+     * Returns the row only if the token exists, has not been used, and
+     * has not expired. Returns false otherwise.
+     *
+     * @param string $token The reset token
+     * @return object|bool The reset record on success, false otherwise
+     */
+    public function find_active_reset_token(string $token): object|bool {
+        $sql = 'SELECT * FROM password_resets'
+             . ' WHERE token = :token'
+             . '   AND used = 0'
+             . '   AND expiry_date > :now'
+             . ' LIMIT 1';
+
+        $rows = $this->db->query_bind($sql, [
+            'token' => $token,
+            'now' => time()
+        ], 'object');
+
+        return !empty($rows) ? $rows[0] : false;
+    }
+
+    /**
+     * Find any reset-token row by token string, regardless of state.
+     *
+     * Returns the row whether the token has been used or has expired.
+     * Used when the consumed/expired-token error page needs to derive
+     * the originating user level so it can link back to the correct
+     * forgot-password form.
+     *
+     * @param string $token The reset token
+     * @return object|bool The reset record on success, false if no such row
+     */
+    public function find_reset_token_row(string $token): object|bool {
+        $sql = 'SELECT * FROM password_resets WHERE token = :token LIMIT 1';
+
+        $rows = $this->db->query_bind($sql, ['token' => $token], 'object');
+
+        return !empty($rows) ? $rows[0] : false;
+    }
+
+    /**
+     * Mark a reset-token row as used.
+     *
+     * Idempotent — running this against an already-consumed token is a no-op.
+     *
+     * @param string $token The reset token
+     * @return void
+     */
+    public function mark_reset_token_used(string $token): void {
+        $sql = 'UPDATE password_resets SET used = 1 WHERE token = :token';
+        $this->db->query_bind($sql, ['token' => $token]);
+    }
+
+    // -----------------------------------------------------------------
+    // Password Hash Write
+    // -----------------------------------------------------------------
+
+    /**
+     * Write a pre-hashed password to a target table.
+     *
+     * Verifies that the target table contains both the identifier column
+     * and the password column before issuing the UPDATE. Returns false if
+     * either column is missing, rather than corrupting the row. The hash
+     * is computed by the controller — this method does not hash.
+     *
+     * @param string $target_table The user table
+     * @param string $identifier_column The column to match on
+     * @param string $identifier_value The value to match
+     * @param string $password_field The column that stores the hashed password
+     * @param string $hash The pre-computed bcrypt hash to write
+     * @return bool True on success, false if the table or columns are wrong
+     */
+    public function write_password_hash_for_identifier(
+        string $target_table,
+        string $identifier_column,
+        string $identifier_value,
+        string $password_field,
+        string $hash
+    ): bool {
+        $columns = $this->db->describe_table($target_table, false);
+
+        if ($columns === false || !is_array($columns)) {
+            return false;
+        }
+
+        $names = array_column($columns, 'Field');
+
+        if (!in_array($identifier_column, $names, true)) {
+            return false;
+        }
+
+        if (!in_array($password_field, $names, true)) {
+            return false;
+        }
+
+        $sql = 'UPDATE ' . $this->quote_id($target_table)
+             . ' SET ' . $this->quote_id($password_field) . ' = :hash'
+             . ' WHERE ' . $this->quote_id($identifier_column) . ' = :identifier';
+
+        $this->db->query_bind($sql, [
+            'hash' => $hash,
+            'identifier' => $identifier_value
+        ]);
+
+        return true;
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    /**
+     * Safely quote a database identifier.
+     *
+     * @param string $id Table or column name
+     * @return string Safely quoted identifier
+     */
+    private function quote_id(string $id): string {
+        return '`' . preg_replace('/[^a-zA-Z0-9_]/', '', $id) . '`';
+    }
+
+}


### PR DESCRIPTION
Extracts password hashing, verification, reset-token lifecycle, and reset-email delivery from Login_model into a dedicated child module. Login_model now delegates these operations so the same bcrypt cost factor and reset logic is reused across the module.

Adds optional password-strength rules in config/login.php (min length, character-class requirements, denylist) consumed by the new password_handler->validate_strength() helper.