### PR TITLE
Add tg-list icon for CV Builder item management

### DIFF
--- a/public/css/trongate-icons.css
+++ b/public/css/trongate-icons.css
@@ -38,6 +38,14 @@
     transform: translateY(0.03em) scale(1.2);
 }
 
+.tg-list {
+    -webkit-mask-image: url('../trongate-icons/list.svg');
+    mask-image: url('../trongate-icons/list.svg');
+    transform: translateY(0.06em) scale(1.2);
+    margin-left: 0.1em;
+    margin-right: -0.1em;
+}
+
 .tg-padlock {
     -webkit-mask-image: url('../trongate-icons/padlock.svg');
     mask-image: url('../trongate-icons/padlock.svg');

--- a/public/trongate-icons/list.svg
+++ b/public/trongate-icons/list.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="8" y1="6" x2="21" y2="6"/>
+  <line x1="8" y1="12" x2="21" y2="12"/>
+  <line x1="8" y1="18" x2="21" y2="18"/>
+  <circle cx="4" cy="6" r="1.5"/>
+  <circle cx="4" cy="12" r="1.5"/>
+  <circle cx="4" cy="18" r="1.5"/>
+</svg>


### PR DESCRIPTION
Adds a new `tg-list` icon (bullet list) to the Trongate icon set, plus its SVG and CSS mask definition.

**Files changed:**
- `public/trongate-icons/list.svg` — new SVG icon (bullet list with three items)
- `public/css/trongate-icons.css` — adds `.tg-list` CSS class using the new SVG mask

The icon was created for use in the JBS CV Builder module where it represents a 'Manage Items' action on category rows.