### PR TITLE
Increase tg-list bullet-to-line spacing

### DIFF
--- a/public/trongate-icons/list.svg
+++ b/public/trongate-icons/list.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <line x1="8" y1="6" x2="21" y2="6"/>
-  <line x1="8" y1="12" x2="21" y2="12"/>
-  <line x1="8" y1="18" x2="21" y2="18"/>
+  <line x1="9" y1="6" x2="20" y2="6"/>
+  <line x1="9" y1="12" x2="20" y2="12"/>
+  <line x1="9" y1="18" x2="20" y2="18"/>
   <circle cx="4" cy="6" r="1.5"/>
   <circle cx="4" cy="12" r="1.5"/>
   <circle cx="4" cy="18" r="1.5"/>


### PR DESCRIPTION
Refines the `tg-list` icon (added in #234) by increasing the gap between the bullet circles and the horizontal lines, with a corresponding reduction in line length for visual balance.