### PR TITLE
Add 'download' to Core.php asset directory allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The Trongate project uses the version format: `{major version}.{year}.{month}{da
 
 The current version of the framework is documented in its [license.txt](https://github.com/trongate/trongate-framework/blob/master/license.txt) file.
 
+## [2.2026.0525] - 2026-07-02
+
+### Added
+- **Core asset serving** — `'download'` added to the directory allowlist in `Core.php`. Module authors can now serve downloadable files from a `download/` subdirectory within their module, enabling clean self-contained backup-distribution endpoints without requiring changes outside the module. ([#243](https://github.com/trongate/trongate-framework/pull/243))
+
 ## [2.2026.0524] - 2026-06-24
 
 ### Fixed

--- a/engine/Core.php
+++ b/engine/Core.php
@@ -299,6 +299,7 @@ class Core {
                   'audio',
                   'css',
                   'documents',
+                  'download',
                   'downloads',
                   'files',
                   'fonts',

--- a/license.txt
+++ b/license.txt
@@ -1,7 +1,7 @@
 /**
  * Trongate
  *
- * Version: 2.2026.0524
+ * Version: 2.2026.0525
  *
  * This product is released under the MIT License (MIT).
  *


### PR DESCRIPTION
## Summary

Adds `'download'` as a permitted subdirectory name in `Core.php`'s asset directory allowlist.

## Motivation

Module authors currently cannot serve assets from a `download/` subdirectory within their module — the framework's asset serving system rejects any directory not in the allowlist. The allowlist already includes `downloads` (plural) but lacks the singular form `download`.

## Change

A single-line addition to the `$allowed_asset_dirs` array in `engine/Core.php`:

```php
'download',
```

## Version

Bumped from `2.2026.0524` to `2.2026.0525` in `license.txt`.