### PR TITLE
Add Quick Start documentation link to config/login.php and Login.php

### DIFF
--- a/config/login.php
+++ b/config/login.php
@@ -2,6 +2,8 @@
 /**
  * Login Module Configuration
  *
+ * 🔗 Quick start guide: https://trongate.io/documentation/trongate_way/understanding-trongates-login-system/quick-start
+ *
  * Defines authentication rules per user level. Each user level maps to a
  * target database table and specifies which columns serve as login identifiers,
  * where to redirect after login, and which view file to use for the login form.

--- a/modules/login/Login.php
+++ b/modules/login/Login.php
@@ -2,6 +2,8 @@
 /**
  * Login Module
  *
+ * 🔗 Quick start guide: https://trongate.io/documentation/trongate_way/understanding-trongates-login-system/quick-start
+ *
  * Portable, configurable authentication module for Trongate v2.
  * Supports multiple user levels, each with its own target table,
  * field mappings, and view files.


### PR DESCRIPTION
Adds a documentation reference link at the top of both `config/login.php` and `modules/login/Login.php`, pointing developers to the new Quick Start guide:

https://trongate.io/documentation/trongate_way/understanding-trongates-login-system/quick-start

This gives developers an immediate path to beginner-friendly documentation the moment they open either file.