### PR TITLE
Fix: Flo decimal price fields corrupt generated create form; empty order_by breaks generated manage SQL

### DIFF
--- a/modules/trongate_control/evo/Evo.php
+++ b/modules/trongate_control/evo/Evo.php
@@ -285,7 +285,7 @@ class Evo extends Trongate {
             'record_name_plural' => $wizard['record_name_plural'] ?? 'Records',
             'nav_label' => $wizard['nav_label'] ?? '',
             'urlColumn' => $wizard['url_column'] ?? '',
-            'orderBy' => $wizard['order_by'] ?? 'id',
+            'orderBy' => (!empty($wizard['order_by'])) ? $wizard['order_by'] : 'id',
             'properties' => json_encode($wizard['properties'] ?? []),
             'icon_id' => $wizard['icon_id'] ?? '',
             'icon_code' => $wizard['icon_code'] ?? '',
@@ -373,7 +373,7 @@ class Evo extends Trongate {
                 'nav_label' => $wizard['nav_label'] ?? '',
                 'properties' => json_encode($wizard['properties'] ?? []),
                 'urlColumn' => $wizard['url_column'] ?? '',
-                'orderBy' => $wizard['order_by'] ?? 'id'
+                'orderBy' => (!empty($wizard['order_by'])) ? $wizard['order_by'] : 'id'
             ];
 
             $this->view('module_details_iframe', $data);

--- a/modules/trongate_control/site_builder/model_helper.php
+++ b/modules/trongate_control/site_builder/model_helper.php
@@ -89,23 +89,20 @@ function build_form_field_row($posted_property) {
     if ($num_validation_rules < 1) {
         $row_str.= $indent.'echo '.$method_start.'(\''.$form_field_name.'\', $'.$form_field_name.', [\'placeholder\' => \'Enter '.$form_field_label.'\']);'.PHP_EOL;
     } else {
-        $row_str.= $indent.'$'.$form_field_name.'_attr = ['.PHP_EOL;
-        $row_str.= $indent.'    \'placeholder\' => \'Enter '.$form_field_label.'\','.PHP_EOL;
-        $counter = 0;
+        $attr_lines = [
+            $indent.'    \'placeholder\' => \'Enter '.$form_field_label.'\''
+        ];
         foreach($posted_property->validation_rules as $validation_rule) {
-            $counter++;
-            $attr_validation_code= build_attr_validation_code($validation_rule, $indent);
+            $attr_validation_code = build_attr_validation_code($validation_rule, $indent);
             if ($attr_validation_code !== '') {
-                $row_str.= $attr_validation_code;
-                if ($counter < $num_validation_rules) {
-                    $row_str.= ',';
-                }
-                $row_str.= PHP_EOL;
+                $attr_lines[] = $attr_validation_code;
             }
         }
         if ($posted_property->property_type === 'decimal') {
-            $row_str.= $indent.'    \'step\' => \'any\','.PHP_EOL;
+            $attr_lines[] = $indent.'    \'step\' => \'any\'';
         }
+        $row_str.= $indent.'$'.$form_field_name.'_attr = ['.PHP_EOL;
+        $row_str.= implode(','.PHP_EOL, $attr_lines).PHP_EOL;
         $row_str.= $indent.'];'.PHP_EOL;
         $row_str.= $indent.'echo '.$method_start.'(\''.$form_field_name.'\', $'.$form_field_name.', $'.$form_field_name.'_attr);'.PHP_EOL;
     }
@@ -120,19 +117,19 @@ function build_attr_validation_code($validation_rule, $indent) {
             break;
         case 'min length':
             $rule_value = extract_rule_value($validation_rule);
-            $code = $indent.'    \'minlength\' => '.$rule_value;
+            $code = $indent.'    \'minlength\' => '.build_attr_rule_value($rule_value);
             break;
         case 'max length':
             $rule_value = extract_rule_value($validation_rule);
-            $code = $indent.'    \'maxlength\' => '.$rule_value;
+            $code = $indent.'    \'maxlength\' => '.build_attr_rule_value($rule_value);
             break;
         case 'greater than':
             $rule_value = extract_rule_value($validation_rule);
-            $code = $indent.'    \'min\' => '.$rule_value;
+            $code = $indent.'    \'min\' => '.build_attr_rule_value($rule_value);
             break;
         case 'less than':
             $rule_value = extract_rule_value($validation_rule);
-            $code = $indent.'    \'max\' => '.$rule_value;
+            $code = $indent.'    \'max\' => '.build_attr_rule_value($rule_value);
             break;
         case 'in the past':
             $code = $indent.'    \'data-date-constraint\' => \'past\'';
@@ -149,6 +146,9 @@ function build_attr_validation_code($validation_rule, $indent) {
 function extract_rule_value($validation_rule) {
     $rule_value = extract_content($validation_rule, '[', ']');
     return $rule_value;
+}
+function build_attr_rule_value($rule_value) {
+    return is_numeric($rule_value) ? $rule_value : var_export($rule_value, true);
 }
 function extract_rule_name($rule) {
     $pos = strpos($rule, '[');


### PR DESCRIPTION
## Summary

Two defects in the Flo/Evo module generator, both triggered by the "decimal" property type used for price fields.

### Bug 1 — Decimal price field generates syntactically invalid PHP

`site_builder/model_helper.php` emitted attribute commas based on the **total** validation-rule count rather than the number of **emitted** attribute lines. A decimal property's default rules (`required`, `max length[7,2]`, `numeric`, `greater than[0]`) emit no code for `numeric`, so the generated `create.php` lost a comma between `'min' => 0` and `'step' => 'any'`:

```php
// before (parse error on line 11)
$price_attr = [
    'placeholder' => 'Enter Price',
    'required'  => true,
    'maxlength' => 7,2,        // raw value also broke the array
    'min' => 0
    'step' => 'any',           // ← missing comma above → PHP Parse error
];
```

Fix:
- Attribute lines are now collected into an array and joined with `,` — commas are only placed between lines that are actually emitted.
- Non-numeric rule values (e.g. `max length[7,2]`) are safely quoted via a new `build_attr_rule_value()` helper: `'maxlength' => '7,2'`.

```php
// after — valid PHP, lints clean
$price_attr = [
    'placeholder' => 'Enter Price',
    'required'  => true,
    'maxlength' => '7,2',
    'min' => 0,
    'step' => 'any'
];
echo form_number('price', $price, $price_attr);
```

### Bug 2 — Empty order_by selection breaks generated manage page (SQLSTATE 1064)

The wizard's "Choose Default Order By" step explicitly offers an empty selection ("Submit empty option if not required"), which `submit_order_by()` stores verbatim. `run_gen()` used `$wizard['order_by'] ?? 'id'` — a fallback that only guards a **missing** key, not an **empty string** — so the generated model contained:

```sql
SELECT * FROM products ORDER BY  LIMIT 20 OFFSET 0
```

→ `SQLSTATE[42000]: 1064 ... near 'LIMIT 20 OFFSET 0'` on every `manage` page. (The Module Details overlay was unaffected because it validates `orderBy` as `required`.)

Fix: `run_gen()` (and the module details iframe preview seeding) now treat an empty `order_by` as `'id'`.

## Verification

- Full wizard run against a local dev app (Flo → Evo → generate) using a decimal `Price` property with `max length[7,2]` and an **empty** order_by selection:
  - All 8 generated PHP files pass `php -l`.
  - Generated table: `price decimal(10,2)`; `8.99` round-trips correctly.
  - `SELECT * FROM test_products ORDER BY id LIMIT 20 OFFSET 0` executes cleanly.
  - Regression matrix: varchar, textarea, int, boolean, email, date, time, date+time, and a second decimal (`max length[3,1]` + `less than`) all generate lint-clean forms.