### PR TITLE
Fix: remove empty 'order by' option from Evo wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The Trongate project uses the version format: `{major version}.{year}.{month}{da
 
 The current version of the framework is documented in its [license.txt](https://github.com/trongate/trongate-framework/blob/master/license.txt) file.
 
+## [2.2026.0731] - 2026-07-31
+
+### Fixed
+- **Flo/Evo module generator** (`site_builder`) — decimal properties (e.g. price fields) no longer produce syntactically invalid PHP in the generated `create.php`: attribute commas are now emitted only between lines that are actually generated, and non-numeric rule values such as `max length[7,2]` are safely quoted. ([#247](https://github.com/trongate/trongate-framework/pull/247))
+- **Flo/Evo module generator** (`evo`) — the 'Choose Default Order By' wizard step no longer offers an empty-string option, and `submit_order_by()` rejects empty or malformed selections. Generation also falls back to `ORDER BY id` when the session value is empty, preventing `SQLSTATE[42000]` errors on generated manage pages. ([#247](https://github.com/trongate/trongate-framework/pull/247), [#248](https://github.com/trongate/trongate-framework/pull/248))
+
 ## [2.2026.0714] - 2026-07-14
 
 ### Fixed

--- a/license.txt
+++ b/license.txt
@@ -1,7 +1,7 @@
 /**
  * Trongate
  *
- * Version: 2.2026.0714
+ * Version: 2.2026.0731
  *
  * This product is released under the MIT License (MIT).
  *

--- a/modules/trongate_control/evo/Evo.php
+++ b/modules/trongate_control/evo/Evo.php
@@ -237,6 +237,13 @@ class Evo extends Trongate {
      */
     public function submit_order_by(): void {
         $selected = post('selected', true);
+
+        // A default order by is mandatory — never accept an empty or malformed selection.
+        if ($selected === '' || !preg_match('/^[a-z0-9_]+( DESC)?$/', $selected)) {
+            echo $this->render_error('Please choose a valid option for the default order by.');
+            return;
+        }
+
         $_SESSION['evo_wizard']['order_by'] = $selected;
 
         $data['view_module'] = 'trongate_control/evo';

--- a/modules/trongate_control/evo/views/choose_order_by.php
+++ b/modules/trongate_control/evo/views/choose_order_by.php
@@ -1,11 +1,9 @@
 <div class="mt-1">Choose Default Order By</div>
 <div class="mt-1">
     <button class="selector-btn" onclick="document.querySelector('main').innerHTML=document.getElementById('ob-options-list').innerHTML">Select Option...</button>
-    <p>Submit empty option if not required</p>
 </div>
 <div id="ob-options-list" style="display:none">
     <ul class="options-selector">
-        <li mx-post="trongate_control-evo/submit_order_by" mx-target="main" mx-target-loading="cloak" mx-vals='{"selected":""}'></li>
         <?php
         $order_by_options = [
             ['propertyName' => 'id', 'column' => 'id'],


### PR DESCRIPTION
## Summary

Follow-up to #247. The "Choose Default Order By" step in the Flo/Evo wizard still presented an **empty-string option** — a `<li>` with `mx-vals='{"selected":""}'` and the hint *"Submit empty option if not required"*.

Since a default order by is **mandatory** (the generated model interpolates it into every `ORDER BY` clause), offering an empty choice was an error: it produced `ORDER BY  LIMIT 20 OFFSET 0` (SQLSTATE 1064) on every manage page, which #247 patched downstream in `run_gen()`.

This PR removes the defect at its source:

### `choose_order_by.php`
- Removed the empty `<li>` option.
- Removed the misleading *"Submit empty option if not required"* hint.
- The user is now offered only: `id`, `id DESC`, and each table column (plus `DESC` variants).

### `Evo.php` — `submit_order_by()`
- Defense in depth: empty or malformed selections (anything not matching `^[a-z0-9_]+( DESC)?$`) are rejected with a friendly error and never stored in the wizard session.

## Verification (live wizard run against local dev app)

- Options list renders with six valid choices only — no empty `<li>`, no hint text.
- `POST selected=` → `"Please choose a valid option for the default order by."`, wizard does not advance.
- `POST selected=price; DROP TABLE x` → same rejection.
- `POST selected=price DESC` → proceeds to the generate screen as normal.