### PR TITLE
Block non-public controller methods from URL invocation; bump transferer.css font size

### DIFF
--- a/engine/Core.php
+++ b/engine/Core.php
@@ -160,6 +160,16 @@ class Core {
         $controller_instance = new $controller_class($this->current_module);
 
         if (method_exists($controller_instance, $this->current_method)) {
+            // Private and protected methods can never be invoked via the URL.
+            // Only public methods are reachable from the dispatcher — anything
+            // else is treated as a non-existent page (404), exactly like the
+            // underscore shortcut handled in serve_controller().
+            $method = new \ReflectionMethod($controller_instance, $this->current_method);
+            if (!$method->isPublic()) {
+                $this->draw_error_page();
+                return;
+            }
+
             try {
                 $controller_instance->{$this->current_method}();
             } catch (\ArgumentCountError) {

--- a/modules/trongate_control/css/transferer.css
+++ b/modules/trongate_control/css/transferer.css
@@ -45,7 +45,7 @@ textarea {
     width: 80%;
     margin: 0 auto;
     height: 50vh;
-    font-size: 0.6em;
+    font-size: .9em;
 }
 
 .warning {


### PR DESCRIPTION
Three small improvements carried over from the z1 test instance:

1. **ReflectionMethod guard** (engine/Core.php, +10 lines) — controller methods that are private or protected now produce a clean 404 when invoked via URL, instead of a fatal 500. This completes the three documented URL-protection mechanisms: block_url() (403), the underscore-first convention (404, enforced at the routing stage), and PHP method visibility (404, clean). Internal calls via Modules::run() and in-class calls are unaffected.

2. **transferer.css** (modules/trongate_control/css/transferer.css) — textarea font-size raised from 0.6em to 0.9em for readability.

3. **Version bump** — 2.2026.0801 in license.txt + CHANGELOG.md entry.

All changes apply cleanly to master.