### PR TITLE
Bump version to 2.2026.0801

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The Trongate project uses the version format: `{major version}.{year}.{month}{da
 
 The current version of the framework is documented in its [license.txt](https://github.com/trongate/trongate-framework/blob/master/license.txt) file.
 
+## [2.2026.0801] - 2026-08-01
+
+### Added
+- **URL protection** (`engine/Core.php`) — private and protected controller methods now return a clean 404 (instead of a fatal 500) when invoked via the URL, thanks to a new `ReflectionMethod` guard in the dispatcher. This completes the three documented mechanisms for preventing URL access to controller methods: `block_url()` (403 Forbidden), the underscore-first convention (404, enforced at the routing stage before the controller loads), and PHP method visibility (404, clean). Internal calls via `Modules::run()` and in-class calls are unaffected. ([#249](https://github.com/trongate/trongate-framework/pull/249))
+
+### Changed
+- **Flo/Evo code generator** (`trongate_control`) — the textarea font size in `transferer.css` was raised from `0.6em` to `0.9em` for improved readability. ([#249](https://github.com/trongate/trongate-framework/pull/249))
+
 ## [2.2026.0731] - 2026-07-31
 
 ### Fixed

--- a/license.txt
+++ b/license.txt
@@ -1,7 +1,7 @@
 /**
  * Trongate
  *
- * Version: 2.2026.0731
+ * Version: 2.2026.0801
  *
  * This product is released under the MIT License (MIT).
  *


### PR DESCRIPTION
Version bump to 2.2026.0801 (license.txt) with the matching CHANGELOG.md entry.

The changelog entry covers the changes already merged into master via #249 (ReflectionMethod guard for non-public controller methods + transferer.css textarea font size). This PR carries the release version and changelog only.