### PR TITLE
Remove duplicate docblock on File::generate_secure_filename()

### DIFF
--- a/modules/file/File.php
+++ b/modules/file/File.php
@@ -502,19 +502,6 @@ class File {
     }
 
     /**
-    * Generates a secure filename for an uploaded file, either randomized or based on original name.
-    *
-    * @param string $original_name The original filename from the upload
-    * @param bool $make_rand_name Whether to generate a random filename (default: false)
-    * 
-    * @return array{
-    *    name: string,           The base filename without extension
-    *    extension: string,      The lowercase file extension
-    *    full_name: string      The complete filename with extension
-    * }
-    */
-
-    /**
      * Generates a secure filename for an uploaded file, either randomized or sanitized from original.
      *
      * This method creates a safe filename suitable for filesystem storage by either generating


### PR DESCRIPTION
## Summary

Removes a stacked duplicate docblock above `File::generate_secure_filename()` in `modules/file/File.php`.

## The problem

Two consecutive docblocks documented the same private method. The first (lines ~505-516) is the older, less accurate version — non-standard `*` indentation and it describes the filename as "based on original name" with a loose return shape. The second (~518-534) is the current, accurate version covering null-byte protection, transliteration and the `sanitize_filename()` approach.

## The fix

Removed the older block; kept the newer, complete one.

## Impact

None at runtime — documentation cleanup only. `php -l` passes.