### PR TITLE
fix: allow documented regenerate() token-rotation endpoint

### DIFF
--- a/modules/trongate_tokens/Trongate_tokens.php
+++ b/modules/trongate_tokens/Trongate_tokens.php
@@ -15,7 +15,10 @@ class Trongate_tokens extends Trongate {
      */
     public function __construct(?string $module_name = null) {
         parent::__construct($module_name);
-        block_url('trongate_tokens');
+        // The regenerate endpoint is intentionally URL-accessible (documented token rotation); block everything else.
+        if (segment(2) !== 'regenerate') {
+            block_url('trongate_tokens');
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

The `trongate_tokens` module's constructor blocks direct URL access to the entire module:

```php
public function __construct(?string $module_name = null) {
    parent::__construct($module_name);
    block_url('trongate_tokens');
}
```

This silently defeats the documented `regenerate()` endpoint. The official documentation ([regenerate.html](https://trongate.io/documentation/assets/reference/included/trongate_tokens/regenerate.html)) shows a JavaScript example that performs a direct HTTP GET to:

```
BASE_URL + 'trongate_tokens/regenerate/' + token + '/' + expiryTimestamp
```

Because `block_url()` runs in the constructor — before method dispatch — every request to that URL returns `403 Forbidden - Direct URL access not permitted`. `Modules::run()` cannot substitute: v2's design is explicit data passing with zero segment guessing, so it can never supply the `segment(3)`/`segment(4)` values the method reads. The direct URL is the method's only viable invocation, and it is blocked.

## Fix

Exempt the documented endpoint from the block; all other methods remain URL-blocked:

```php
public function __construct(?string $module_name = null) {
    parent::__construct($module_name);
    // The regenerate endpoint is intentionally URL-accessible (documented token rotation); block everything else.
    if (segment(2) !== 'regenerate') {
        block_url('trongate_tokens');
    }
}
```

## Verification (live, against master)

- `GET /trongate_tokens/regenerate/{token}/{expiry}` on master → **403** (block fires before dispatch); `/welcome` → 200 control.
- With the fix applied:
  - Valid token + future expiry → **200**, fresh 32-char token returned;
  - Old token immediately after → **404** (rotation invalidates it, per the documentation's security rationale);
  - Bad expiry format → **400**; unknown token → **404**;
  - Other methods (`destroy`, etc.) → still **403**.