### PR TITLE
fix: correct from_trongate_mx() docblock header name

### DIFF
--- a/engine/tg_helpers/utilities_helper.php
+++ b/engine/tg_helpers/utilities_helper.php
@@ -102,7 +102,7 @@ function sort_rows_by_property(array $array, string $property, string $direction
 /**
  * Checks if the HTTP request has been invoked by Trongate MX.
  *
- * @return bool True if the request has the X-Trongate-MX header set to 'true', otherwise false.
+ * @return bool True if the request has the Trongate-MX-Request header set to 'true', otherwise false.
  */
 function from_trongate_mx(): bool {
     return Modules::run('utilities/from_trongate_mx');

--- a/modules/utilities/Utilities.php
+++ b/modules/utilities/Utilities.php
@@ -183,7 +183,7 @@ class Utilities extends Trongate {
     /**
      * Checks if the HTTP request has been invoked by Trongate MX.
      *
-     * @return bool True if the request has the X-Trongate-MX header set to 'true', otherwise false.
+     * @return bool True if the request has the Trongate-MX-Request header set to 'true', otherwise false.
      */
     public function from_trongate_mx(): bool {
         if (isset($_SERVER['HTTP_TRONGATE_MX_REQUEST'])) {


### PR DESCRIPTION
## Summary

The docblocks for `from_trongate_mx()` (both the `Utilities` module method and the `utilities_helper.php` wrapper) reference the header as **X-Trongate-MX**. The actual header sent by the Trongate MX engine is **`Trongate-MX-Request: true`** (`trongate-mx.js:189`), which PHP surfaces as `$_SERVER['HTTP_TRONGATE_MX_REQUEST']` — exactly what the implementation checks.

## Change

Two documentation-only line edits, no behaviour change:

- `modules/utilities/Utilities.php` — @return docblock
- `engine/tg_helpers/utilities_helper.php` — @return docblock

Verified against the MX book (`0020Core_HTTP_Operations/0050identifying_trongate_mx_requests.html`), which already documents the header correctly as `Trongate-MX-Request`.

— Grady 🎩