### PR TITLE
Fix #237: validation errors lost when summary call follows form_close()

### DIFF
--- a/modules/form/Form.php
+++ b/modules/form/Form.php
@@ -288,9 +288,7 @@ class Form extends Trongate {
         // Use Modules::run() to access validation module
         $js_injection = Modules::run('validation/get_js_injection');
         $html .= $js_injection;
-        
-        // Clear validation errors to prevent them from persisting to other forms
-        unset($_SESSION['form_submission_errors']);
+
         return $html;
     }
 

--- a/modules/validation/Validation.php
+++ b/modules/validation/Validation.php
@@ -240,6 +240,9 @@ class Validation extends Trongate {
             return false;
         }
 
+        // Clear-on-pass: a successful submission must not display stale errors
+        $this->form_submission_errors = [];
+        unset($_SESSION['form_submission_errors']);
         return true;
     }
 


### PR DESCRIPTION
## The bug

`form_close()` unconditionally destroys the validation error bucket (`Form.php:293`). A summary call placed after the form — a natural placement for the docs pattern — renders nothing. Credit to **jchouix** for the initial report and diagnosis on **#237**.

## The fix (two halves, shipped together)

1. **Remove the destructive `unset()` from `form_close()`.** The bucket's lifecycle is render-and-clear: only a rendering call (`validation_errors()`) deletes it.
2. **Add clear-on-pass to `Validation::run()`.** Without it, removing the unset creates a stale-flash corner: a failing submission whose page never renders a summary call leaves the bucket alive, and a later *passing* submission on a page with a summary call would display stale errors.

The two changes are **not safe in isolation** — they ship as one PR.

## After this PR

A summary call renders from any placement: before the form, inside the block, or after `form_close()`.

The companion PR (scoped validation errors for multi-form pages) builds on this change.

## Test matrix

- Single-form page: pre-open, in-block, and post-close placements all render
- Fail → render → later pass: no stale errors (clear-on-pass)
- Fail → never rendered → later pass on a page with a summary call: no stale errors
- Multi-form page: bucket survives all `form_close()` calls (the reported bug)