### PR TITLE
Feat #237: scoped validation errors via explicit form names

### DIFF
--- a/engine/tg_helpers/form_helper.php
+++ b/engine/tg_helpers/form_helper.php
@@ -433,6 +433,6 @@ function post(
  * @param string|null $closing_html Optional HTML to close each error message.
  * @return string|null Returns a string of formatted validation errors or null if no errors are present.
  */
-function validation_errors(string|int|null $first_arg = null, ?string $closing_html = null): ?string {
-    return Modules::run('validation/display_errors', ['first_arg' => $first_arg, 'closing_html' => $closing_html]);
+function validation_errors(string|int|null $first_arg = null, ?string $closing_html = null, ?string $scope = null): ?string {
+    return Modules::run('validation/display_errors', ['first_arg' => $first_arg, 'closing_html' => $closing_html, 'scope' => $scope]);
 }

--- a/modules/form/Form.php
+++ b/modules/form/Form.php
@@ -288,9 +288,7 @@ class Form extends Trongate {
         // Use Modules::run() to access validation module
         $js_injection = Modules::run('validation/get_js_injection');
         $html .= $js_injection;
-        
-        // Clear validation errors to prevent them from persisting to other forms
-        unset($_SESSION['form_submission_errors']);
+
         return $html;
     }
 

--- a/modules/form/Form.php
+++ b/modules/form/Form.php
@@ -241,6 +241,14 @@ class Form extends Trongate {
             $method = $attributes['method'];
             unset($attributes['method']);
         }
+
+        // Extract the form name (used for scoped validation errors).
+        // It is never rendered as an HTML attribute on the form tag.
+        $form_name = null;
+        if (isset($attributes['form_name'])) {
+            $form_name = $attributes['form_name'];
+            unset($attributes['form_name']);
+        }
         
         foreach ($attributes as $key => $value) {
             $extra .= ' ' . htmlspecialchars($key, ENT_QUOTES, 'UTF-8') . '="' . htmlspecialchars($value, ENT_QUOTES, 'UTF-8') . '"';
@@ -250,7 +258,15 @@ class Form extends Trongate {
             $location = BASE_URL . $location;
         }
 
-        return '<form action="' . htmlspecialchars($location, ENT_QUOTES, 'UTF-8') . '" method="' . htmlspecialchars($method, ENT_QUOTES, 'UTF-8') . '"' . $extra . '>';
+        $html = '<form action="' . htmlspecialchars($location, ENT_QUOTES, 'UTF-8') . '" method="' . htmlspecialchars($method, ENT_QUOTES, 'UTF-8') . '"' . $extra . '>';
+
+        // Mirror run()'s key-hygiene cap (<=64): a name run() would never
+        // record must not be injected, so declared and recorded never diverge
+        if (is_string($form_name) && $form_name !== '' && strlen($form_name) <= 64) {
+            $html .= '<input type="hidden" name="form_name" value="' . htmlspecialchars($form_name, ENT_QUOTES, 'UTF-8') . '">';
+        }
+
+        return $html;
     }
 
     /**

--- a/modules/validation/Validation.php
+++ b/modules/validation/Validation.php
@@ -240,6 +240,9 @@ class Validation extends Trongate {
             return false;
         }
 
+        // Clear-on-pass: a successful submission must not display stale errors
+        $this->form_submission_errors = [];
+        unset($_SESSION['form_submission_errors']);
         return true;
     }
 

--- a/modules/validation/Validation.php
+++ b/modules/validation/Validation.php
@@ -237,22 +237,35 @@ class Validation extends Trongate {
         // 3. Final check for errors (gathered during set_rules phase)
         if (count($this->form_submission_errors) > 0) {
             $_SESSION['form_submission_errors'] = $this->form_submission_errors;
+
+            // Record which form produced this failure (scoped validation errors).
+            // Key hygiene: strings only, trimmed, capped at 64 chars — an array
+            // POST (or anything non-string) can never become a session key.
+            $form_name = $_POST['form_name'] ?? null;
+            if (is_string($form_name)) {
+                $form_name = trim($form_name);
+                if ($form_name !== '' && strlen($form_name) <= 64) {
+                    $_SESSION['form_submission_name'] = $form_name;
+                }
+            }
+
             return false;
         }
 
         // Clear-on-pass: a successful submission must not display stale errors
         $this->form_submission_errors = [];
-        unset($_SESSION['form_submission_errors']);
+        unset($_SESSION['form_submission_errors'], $_SESSION['form_submission_name']);
         return true;
     }
 
     /**
      * Displays validation errors in various formats.
      * 
-     * Supports three render types:
+     * Supports four render types:
      * 1. JSON: When first argument is an HTTP error code (400-499)
-     * 2. Inline: When only first argument is provided (field name)
-     * 3. Standard: When both opening and closing HTML tags are provided
+     * 2. Scoped: When first argument starts with 'FORM-' (form name)
+     * 3. Inline: When only first argument is provided (field name)
+     * 4. Standard: When both opening and closing HTML tags are provided
      * 
      * @param array<string, mixed> $data The data array containing render parameters
      * @return string|null The rendered error HTML or null if no errors
@@ -260,6 +273,7 @@ class Validation extends Trongate {
     public function display_errors(array $data = []): ?string {
         $first_arg = $data['first_arg'] ?? null;
         $closing_html = $data['closing_html'] ?? null;
+        $scope = $data['scope'] ?? null;
         $render_type = $this->get_render_type($first_arg, $closing_html);
 
         if ($render_type === 'null') {
@@ -268,9 +282,28 @@ class Validation extends Trongate {
 
         $form_submission_errors = $_SESSION['form_submission_errors'];
 
+        // Scoped rendering: resolve the requested name (FORM- prefix spelling
+        // or the position-3 $scope spelling) and render only on an exact match.
+        // Abstain WITHOUT clearing on any mismatch — the correct form's block
+        // must still be able to render the bucket.
+        $requested_name = null;
+        if ($render_type === 'scoped') {
+            $requested_name = substr($first_arg, 5); // strip 'FORM-'
+        } elseif ($render_type === 'standard' && $scope !== null) {
+            $requested_name = $scope;
+        }
+
+        if ($requested_name !== null) {
+            $submission_name = $_SESSION['form_submission_name'] ?? null;
+            if ($submission_name !== $requested_name) {
+                return null; // Abstain — do NOT clear the bucket
+            }
+        }
+
         return match ($render_type) {
             'json'     => $this->json_validation_errors($form_submission_errors, $first_arg),
             'inline'   => $this->inline_validation_errors($form_submission_errors, $first_arg),
+            'scoped'   => $this->general_validation_errors($form_submission_errors),
             'standard' => $this->general_validation_errors($form_submission_errors, $first_arg, $closing_html),
         };
     }
@@ -287,7 +320,7 @@ class Validation extends Trongate {
         header('Content-Type: application/json');
 
         // RENDERED = DELETED
-        unset($_SESSION['form_submission_errors']);
+        unset($_SESSION['form_submission_errors'], $_SESSION['form_submission_name']);
         return json_encode($errors);
     }
 
@@ -314,7 +347,7 @@ class Validation extends Trongate {
 
         // Cleanup: If the array is now empty, remove the parent key
         if (count($_SESSION['form_submission_errors']) === 0) {
-            unset($_SESSION['form_submission_errors']);
+            unset($_SESSION['form_submission_errors'], $_SESSION['form_submission_name']);
         }
 
         return $html;
@@ -342,7 +375,7 @@ class Validation extends Trongate {
         $html = ($items !== '') ? '<ul class="validation-errors validation-errors--summary">' . $items . '</ul>' : '';
 
         // RENDERED = DELETED
-        unset($_SESSION['form_submission_errors']);
+        unset($_SESSION['form_submission_errors'], $_SESSION['form_submission_name']);
         return $html;
     }
 
@@ -351,7 +384,7 @@ class Validation extends Trongate {
      * 
      * @param mixed $first_arg The first argument passed to display_errors
      * @param mixed $closing_html The closing HTML tag argument
-     * @return string The render type: 'json', 'inline', 'standard', or 'null'
+     * @return string The render type: 'json', 'scoped', 'inline', 'standard', or 'null'
      */
     private function get_render_type($first_arg, $closing_html): string {
         if (!isset($_SESSION['form_submission_errors'])) {
@@ -360,6 +393,10 @@ class Validation extends Trongate {
 
         if (is_int($first_arg) && $first_arg >= 400 && $first_arg <= 499) {
             return 'json';
+        }
+
+        if (is_string($first_arg) && str_starts_with($first_arg, 'FORM-')) {
+            return 'scoped';
         }
 
         if (isset($first_arg) && !isset($closing_html)) {


### PR DESCRIPTION
> Depends on **#256** (this branch is stacked on it; the diff shrinks to its own changes once #256 merges).

## Why this exists

`validation_errors()` renders the entire pending error bucket. On a page with more than one form, a summary call inside one form's block can display another form's errors — and after the `form_close()` fix in #256, the bucket survives to be read from anywhere, making attribution the open question.

This PR answers attribution **the explicit way**: the developer names a form at `form_open()`, the framework records that name when validation fails, and a scoped `validation_errors('FORM-<name>')` renders only a matching bucket — abstaining (without clearing) on any mismatch, so the correct form's block still gets to render.

Why explicit rather than derived (e.g. from the URL): the framework's explicit-over-implicit creed; a derived tag would be broken by custom routing and absolute-URL form locations; a declared name has no such corners. Credit to **jchouix** for the original report on **#237**.

## Changes

**`modules/form/Form.php` — `form_open()`**
- Extracts `form_name` from `$attributes` (special-cased exactly like `method`; never rendered as an HTML attribute)
- Injects an escaped hidden field after the opening tag, **opt-in**, with the 64-char cap mirrored from `run()` so declared and recorded can never diverge
- Signature unchanged; `form_open_upload()` inherits the behaviour automatically

**`modules/validation/Validation.php`**
- `run()` failure branch records `$_SESSION['form_submission_name']` — strings only, trimmed, ≤ 64 chars (an array POST can never become a session key)
- `run()` pass branch and all three render paths (json, inline, general) clear the sibling key alongside the bucket
- `get_render_type()` dispatch: null → json → **scoped** → inline → standard
- `display_errors()` resolves the requested name (`FORM-` prefix or position-3 `$scope`) and abstains without clearing on any mismatch — including a missing recorded name, so an unattributable bucket can never surface under a named form's scoped call

**`engine/tg_helpers/form_helper.php`**
- `validation_errors()` gains a third, optional `$scope` parameter

## API

| Call | Meaning |
|---|---|
| `form_open('tasks/create', ['form_name' => 'login'])` | declare a form name (opt-in) |
| `validation_errors('FORM-login')` | scoped summary, default wrappers |
| `validation_errors('</p>', '<p>', 'login')` | scoped summary, custom wrappers |
| `validation_errors('email')` | inline — unchanged |
| `validation_errors(400)` | JSON — unchanged |
| `validation_errors()` | global summary — unchanged |

## Breaking changes

**None.** All additions are opt-in; existing calls behave exactly as before. The only reservation, documented: a field literally named `FORM-*` (uppercase) is no longer reachable via inline `validation_errors('FORM-*')`.

## Test matrix

- pass+pass → nothing renders; pass+fail → the failing form's block renders, the other abstains (bucket survives)
- Wrong-name call → abstains without clearing; unnamed failing form + scoped call → abstains (global call still renders)
- Single-form page: pre-open global, in-block scoped, post-close global — all placements work
- Inline unaffected by a recorded name; MX JSON wire shape byte-identical (hidden field travels in FormData; JSON path never reads the name key)
- Array POST (`form_name[]=x`) → name not recorded, no crash